### PR TITLE
Fixing wrong quicksend calls in Osci1T_TrigSet and TCPLog_ChsSet

### DIFF
--- a/nanonis_spm/NanonisClass.py
+++ b/nanonis_spm/NanonisClass.py
@@ -8527,7 +8527,7 @@ class Nanonis:
         """
         return self.quickSend("TCPLog.Stop", [], [], [])
 
-    def TCPLog_ChsSet(self, Channel_indexes):
+    def TCPLog_ChsSet(self, Num_channels, Channel_indexes):
         """
         TCPLog.ChsSet
         Sets the list of recorded channels in the TCP Logger module.
@@ -8543,7 +8543,7 @@ class Nanonis:
         
         
         """
-        return self.quickSend("TCPLog.ChsSet", [Channel_indexes], ["*i"], [])
+        return self.quickSend("TCPLog.ChsSet", [Num_channels, Channel_indexes], ["i", "*i"], [])
 
     def TCPLog_OversamplSet(self, Oversampling_value):
         """

--- a/nanonis_spm/NanonisClass.py
+++ b/nanonis_spm/NanonisClass.py
@@ -9226,7 +9226,7 @@ class Nanonis:
 
         """
         return self.quickSend("Osci1T.TrigSet", [TriggerMode, TriggerSlope, TriggerLevel, TriggerHysteresis],
-                              ["H", "H", "f", "f"], [])
+                              ["H", "H", "d", "d"], [])
 
     def Osci1T_TrigGet(self, TriggerMode, TriggerChannel, TriggerSlope, TriggerLevel, TriggerHysterstis, TriggerPos):
         """


### PR DESCRIPTION
Changed TriggerLevel and TriggerHysteresis format specifiers from 'f' to 'd' to ensure proper data type handling in the oscilloscope trigger configuration