### PR TITLE
Fix parseGeneralResponse to handle +*c/+*i/+*b format strings

### DIFF
--- a/nanonis_spm/NanonisClass.py
+++ b/nanonis_spm/NanonisClass.py
@@ -252,6 +252,41 @@ class Nanonis:
         Variables = []
         universalLength = 0
         for ResponseType in ResponseTypes:
+            # Handle +*X and -*X format strings (self-contained prepended arrays/strings)
+            if (len(ResponseType) >= 3
+                    and ResponseType[0] in ('+', '-')
+                    and ResponseType[1] == '*'):
+                elem_type = ResponseType[2]
+                if ResponseType[0] == '+':
+                    if elem_type == 'c':
+                        # Self-contained prepended string: 4-byte length + string data
+                        str_len = struct.unpack('>i', Response[counter:counter+4])[0]
+                        counter += 4
+                        string_val = Response[counter:counter+str_len].decode('utf-8', errors='replace')
+                        counter += str_len
+                        Variables.append(string_val)
+                    else:
+                        # Self-contained prepended array: 4-byte count + element data
+                        arr_len = struct.unpack('>i', Response[counter:counter+4])[0]
+                        counter += 4
+                        elem_size = struct.calcsize('>' + elem_type)
+                        result = []
+                        for i in range(arr_len):
+                            val = struct.unpack('>' + elem_type, Response[counter:counter+elem_size])
+                            result.append(val[0])
+                            counter += elem_size
+                        Variables.append(result)
+                else:  # '-'
+                    # Non-prepended array: length from previous variable
+                    arr_len = Variables[-1]
+                    elem_size = struct.calcsize('>' + elem_type)
+                    result = []
+                    for i in range(arr_len):
+                        val = struct.unpack('>' + elem_type, Response[counter:counter+elem_size])
+                        result.append(val[0])
+                        counter += elem_size
+                    Variables.append(result)
+                continue
             if ResponseType[0] != '*':
                 if ResponseType[0] == '2':
                     NoOfRows = Variables[-2]  # no of rows must be directly before cols


### PR DESCRIPTION
## Summary

`parseGeneralResponse()` fails with `struct.error: bad char in struct format` when processing response types that use the `+*X` ordering (e.g. `"+*c"`, `"+*i"`, `"+*b"`).

The codebase uses **two orderings** for the same semantic:
- `"*+c"`, `"*-c"` (star first) — **36 uses**, handled by the parser
- `"+*c"`, `"+*i"`, `"+*b"` (plus/minus first) — **53+ uses**, **not handled**

The `+*X` format is actually **more common** but causes a crash because the parser only checks `ResponseType[0] == '*'`. When the first character is `+`, it falls through to `struct.calcsize('>' + "+*c")`, which is invalid.

### Affected functions

All functions returning strings via `"+*c"`, including:
- `Util_VersionGet` (the most basic connectivity test)
- `Util_SessionPathGet`
- `Scan_PropsGet`, `FolMe_PSPropsGet`, `Bias_RangeGet`, and many more (53+ functions total)

### Root cause

The `+*X` format means a **self-contained** prepended string/array — the length is read directly from the data stream (4-byte big-endian int + data). This is different from `*+c`, where the string count comes from a **previous variable**.

### Fix

Added an early check in the `for ResponseType in ResponseTypes` loop to handle the `+*X` and `-*X` orderings before the existing `*` check. The fix:
- Reads the 4-byte length prefix directly from the response data
- Decodes the string/array inline
- Advances the counter correctly

No changes to the handling of existing `*+c` / `*-c` / `**` formats.

### Testing

Tested against Nanonis Mimea Software (Generic 5e, release 15016) in simulation mode:
- `Util_VersionGet`: returns `['Nanonis Mimea Software', 'Generic 5e', 15016, 15016]`
- Full 264-function test suite passes with the fix applied
- No regressions in `*+c` / `*-c` / `**` format handling